### PR TITLE
Optimize method for initializing cache of versions of OpenTofu

### DIFF
--- a/src/main/java/org/eclipse/xpanse/tofu/maker/opentofu/tool/OpenTofuVersionsCache.java
+++ b/src/main/java/org/eclipse/xpanse/tofu/maker/opentofu/tool/OpenTofuVersionsCache.java
@@ -34,6 +34,8 @@ public class OpenTofuVersionsCache {
         try {
             return versionsFetcher.fetchAvailableVersionsFromOpenTofuWebsite();
         } catch (Exception e) {
+            log.error("Failed to fetch versions from website for OpenTofu, get "
+                    + "versions from default config.", e);
             return versionsFetcher.getDefaultVersionsFromConfig();
         }
     }

--- a/src/main/java/org/eclipse/xpanse/tofu/maker/opentofu/tool/OpenTofuVersionsCacheManager.java
+++ b/src/main/java/org/eclipse/xpanse/tofu/maker/opentofu/tool/OpenTofuVersionsCacheManager.java
@@ -6,11 +6,13 @@
 package org.eclipse.xpanse.tofu.maker.opentofu.tool;
 
 
-import jakarta.annotation.PostConstruct;
+import jakarta.annotation.Nonnull;
 import jakarta.annotation.Resource;
 import java.util.Objects;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationStartedEvent;
+import org.springframework.context.ApplicationListener;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
@@ -20,7 +22,7 @@ import org.springframework.util.CollectionUtils;
  */
 @Slf4j
 @Component
-public class OpenTofuVersionsCacheManager {
+public class OpenTofuVersionsCacheManager implements ApplicationListener<ApplicationStartedEvent> {
 
     @Resource
     private OpenTofuVersionsCache versionsCache;
@@ -28,11 +30,16 @@ public class OpenTofuVersionsCacheManager {
     @Resource
     private OpenTofuVersionsFetcher versionsFetcher;
 
+    @Override
+    public void onApplicationEvent(@Nonnull ApplicationStartedEvent event) {
+        initializeCache();
+    }
+
     /**
      * Initialize the cache of available versions of OpenTofu.
      */
-    @PostConstruct
-    public void initializeCache() {
+    private void initializeCache() {
+        log.info("Initializing OpenTofu versions cache.");
         Set<String> versions = versionsCache.getAvailableVersions();
         log.info("Initialized OpenTofu versions cache with versions:{}.", versions);
     }

--- a/src/main/java/org/eclipse/xpanse/tofu/maker/opentofu/tool/OpenTofuVersionsFetcher.java
+++ b/src/main/java/org/eclipse/xpanse/tofu/maker/opentofu/tool/OpenTofuVersionsFetcher.java
@@ -6,7 +6,11 @@
 package org.eclipse.xpanse.tofu.maker.opentofu.tool;
 
 import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URL;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
@@ -20,8 +24,11 @@ import org.kohsuke.github.GitHubRateLimitHandler;
 import org.kohsuke.github.PagedIterable;
 import org.kohsuke.github.connector.GitHubConnectorResponse;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
+import org.springframework.retry.support.RetrySynchronizationManager;
 import org.springframework.stereotype.Component;
 
 /**
@@ -49,26 +56,54 @@ public class OpenTofuVersionsFetcher {
             maxAttemptsExpression = "${spring.retry.max-attempts}",
             backoff = @Backoff(delayExpression = "${spring.retry.delay-millions}"))
     public Set<String> fetchAvailableVersionsFromOpenTofuWebsite() throws Exception {
+        int retryCount = Objects.isNull(RetrySynchronizationManager.getContext())
+                ? 0 : RetrySynchronizationManager.getContext().getRetryCount();
+        log.info("Start to fetch available versions from website for OpenTofu."
+                + " Retry count: {}", retryCount);
         Set<String> allVersions = new HashSet<>();
-        GitHub gitHub = new GitHubBuilder()
-                .withEndpoint(openTofuGithubApiEndpoint)
-                .withRateLimitHandler(getGithubRateLimitHandler())
-                .build();
-        GHRepository repository = gitHub.getRepository(openTofuGithubRepository);
-        PagedIterable<GHTag> tags = repository.listTags();
-        tags.forEach(tag -> {
-            String version = tag.getName();
-            if (OFFICIAL_VERSION_PATTERN.matcher(version).matches()) {
-                // remove the prefix 'v'
-                allVersions.add(version.substring(1));
+        try {
+            if (!isEndpointReachable(openTofuGithubApiEndpoint)) {
+                String errorMsg = "OpenTofu website is not reachable.";
+                log.error(errorMsg);
+                throw new IOException(errorMsg);
             }
-        });
-        log.info("Get available versions: {} from OpenTofu website.", allVersions);
+            GitHub gitHub = new GitHubBuilder()
+                    .withEndpoint(openTofuGithubApiEndpoint)
+                    .withRateLimitHandler(getGithubRateLimitHandler())
+                    .build();
+            GHRepository repository = gitHub.getRepository(openTofuGithubRepository);
+            PagedIterable<GHTag> tags = repository.listTags();
+            tags.forEach(tag -> {
+                String version = tag.getName();
+                if (OFFICIAL_VERSION_PATTERN.matcher(version).matches()) {
+                    // remove the prefix 'v'
+                    allVersions.add(version.substring(1));
+                }
+            });
+        } catch (Exception e) {
+            log.error("Failed to fetch available versions from OpenTofu website. Retry count: {}",
+                    retryCount, e);
+            throw e;
+        }
+        log.info("Get available versions: {} from OpenTofu website. Retry count: {}", allVersions,
+                retryCount);
         if (allVersions.isEmpty()) {
             String errorMsg = "No available versions found from OpenTofu website.";
             throw new InvalidOpenTofuToolException(errorMsg);
         }
         return allVersions;
+    }
+
+    private boolean isEndpointReachable(String endpoint) throws IOException {
+        try {
+            URL url = URI.create(endpoint).toURL();
+            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+            connection.setConnectTimeout(10000);
+            connection.setRequestMethod(HttpMethod.HEAD.name());
+            return connection.getResponseCode() == HttpStatus.OK.value();
+        } catch (IOException e) {
+            throw new IOException("Failed to connect to the endpoint: " + endpoint);
+        }
     }
 
 


### PR DESCRIPTION
Fixed https://github.com/eclipse-xpanse/xpanse/issues/2089
Related to https://github.com/eclipse-xpanse/xpanse/pull/2090 and https://github.com/eclipse-xpanse/terraform-boot/pull/159
Initializing openTofu versions cache after the application started:
![image](https://github.com/user-attachments/assets/7cfd1b08-62db-48cb-b3de-57ab5bc0f037)
