### PR TITLE
Deployment scripts with multiple files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ jobs:
           java-version: 21
           distribution: 'temurin'
       - name: Set up OpenTofu
-        uses: opentofu/setup-opentofu@v1.0.4
+        uses: opentofu/setup-opentofu@v1.0.5
         with:
-          tofu_version: 1.6.1
+          tofu_version: 1.6.0
       - name: Build
         run: mvn --batch-mode --update-snapshots --no-transfer-progress verify

--- a/src/main/java/org/eclipse/xpanse/tofu/maker/models/plan/OpenTofuPlanWithScriptsRequest.java
+++ b/src/main/java/org/eclipse/xpanse/tofu/maker/models/plan/OpenTofuPlanWithScriptsRequest.java
@@ -6,8 +6,9 @@
 package org.eclipse.xpanse.tofu.maker.models.plan;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
-import java.util.List;
+import java.util.Map;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
@@ -19,8 +20,11 @@ import lombok.EqualsAndHashCode;
 public class OpenTofuPlanWithScriptsRequest extends OpenTofuPlanFromDirectoryRequest {
 
     @NotNull
-    @Schema(description =
-            "List of openTofu script files to be considered for generating openTofu plan")
-    private List<String> scripts;
+    @NotEmpty
+    @Schema(
+            description =
+                    "Map stores file name and content of all script files for generating terraform"
+                            + " plan.")
+    private Map<String, String> scriptFiles;
 
 }

--- a/src/main/java/org/eclipse/xpanse/tofu/maker/models/request/scripts/OpenTofuDeployWithScriptsRequest.java
+++ b/src/main/java/org/eclipse/xpanse/tofu/maker/models/request/scripts/OpenTofuDeployWithScriptsRequest.java
@@ -6,8 +6,9 @@
 package org.eclipse.xpanse.tofu.maker.models.request.scripts;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
-import java.util.List;
+import java.util.Map;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import org.eclipse.xpanse.tofu.maker.models.request.directory.OpenTofuDeployFromDirectoryRequest;
@@ -20,7 +21,10 @@ import org.eclipse.xpanse.tofu.maker.models.request.directory.OpenTofuDeployFrom
 public class OpenTofuDeployWithScriptsRequest extends OpenTofuDeployFromDirectoryRequest {
 
     @NotNull
-    @Schema(description = "List of OpenTofu script files to be considered for deploying changes.")
-    private List<String> scripts;
+    @NotEmpty
+    @Schema(
+            description =
+                    "Map stores file name and content of all script files for deploy request.")
+    private Map<String, String> scriptFiles;
 
 }

--- a/src/main/java/org/eclipse/xpanse/tofu/maker/models/request/scripts/OpenTofuDestroyWithScriptsRequest.java
+++ b/src/main/java/org/eclipse/xpanse/tofu/maker/models/request/scripts/OpenTofuDestroyWithScriptsRequest.java
@@ -6,8 +6,9 @@
 package org.eclipse.xpanse.tofu.maker.models.request.scripts;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
-import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -24,8 +25,11 @@ public class OpenTofuDestroyWithScriptsRequest extends OpenTofuDestroyFromDirect
     private UUID requestId;
 
     @NotNull
-    @Schema(description = "List of script files for destroy requests deployed via scripts")
-    private List<String> scripts;
+    @NotEmpty
+    @Schema(
+            description =
+                    "Map stores file name and content of all script files for destroy request")
+    private Map<String, String> scriptFiles;
 
     @NotNull
     @Schema(description = "The .tfState file content after deployment")

--- a/src/main/java/org/eclipse/xpanse/tofu/maker/models/request/scripts/OpenTofuModifyWithScriptsRequest.java
+++ b/src/main/java/org/eclipse/xpanse/tofu/maker/models/request/scripts/OpenTofuModifyWithScriptsRequest.java
@@ -6,8 +6,9 @@
 package org.eclipse.xpanse.tofu.maker.models.request.scripts;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
-import java.util.List;
+import java.util.Map;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import org.eclipse.xpanse.tofu.maker.models.request.directory.OpenTofuModifyFromDirectoryRequest;
@@ -20,8 +21,11 @@ import org.eclipse.xpanse.tofu.maker.models.request.directory.OpenTofuModifyFrom
 public class OpenTofuModifyWithScriptsRequest extends OpenTofuModifyFromDirectoryRequest {
 
     @NotNull
-    @Schema(description = "List of script files for modify requests deployed via scripts")
-    private List<String> scripts;
+    @NotEmpty
+    @Schema(
+            description =
+                    "Map stores file name and content of all script files for modify request")
+    private Map<String, String> scriptFiles;
 
     @NotNull
     @Schema(description = "The .tfState file content after deployment")

--- a/src/main/java/org/eclipse/xpanse/tofu/maker/opentofu/service/OpenTofuScriptsService.java
+++ b/src/main/java/org/eclipse/xpanse/tofu/maker/opentofu/service/OpenTofuScriptsService.java
@@ -47,10 +47,10 @@ public class OpenTofuScriptsService {
      * /**
      * Method of deployment a service using a script.
      */
-    public OpenTofuValidationResult validateWithScripts(
-            OpenTofuDeployWithScriptsRequest request) {
+    public OpenTofuValidationResult validateWithScripts(OpenTofuDeployWithScriptsRequest request) {
         String taskWorkspace = scriptsHelper.buildTaskWorkspace(UUID.randomUUID().toString());
-        scriptsHelper.prepareDeploymentFilesWithScripts(taskWorkspace, request.getScripts(), null);
+        scriptsHelper.prepareDeploymentFilesWithScripts(taskWorkspace, request.getScriptFiles(),
+                null);
         return directoryService.tfValidateFromDirectory(taskWorkspace,
                 request.getOpenTofuVersion());
     }
@@ -60,9 +60,8 @@ public class OpenTofuScriptsService {
      */
     public OpenTofuResult deployWithScripts(OpenTofuDeployWithScriptsRequest request, UUID uuid) {
         String taskWorkspace = scriptsHelper.buildTaskWorkspace(uuid.toString());
-        List<File> files =
-                scriptsHelper.prepareDeploymentFilesWithScripts(taskWorkspace, request.getScripts(),
-                        null);
+        List<File> files = scriptsHelper.prepareDeploymentFilesWithScripts(taskWorkspace,
+                request.getScriptFiles(), null);
         return directoryService.deployFromDirectory(request, taskWorkspace, files);
     }
 
@@ -71,21 +70,18 @@ public class OpenTofuScriptsService {
      */
     public OpenTofuResult modifyWithScripts(OpenTofuModifyWithScriptsRequest request, UUID uuid) {
         String taskWorkspace = scriptsHelper.buildTaskWorkspace(uuid.toString());
-        List<File> files =
-                scriptsHelper.prepareDeploymentFilesWithScripts(taskWorkspace, request.getScripts(),
-                        request.getTfState());
+        List<File> files = scriptsHelper.prepareDeploymentFilesWithScripts(taskWorkspace,
+                request.getScriptFiles(), request.getTfState());
         return directoryService.modifyFromDirectory(request, taskWorkspace, files);
     }
 
     /**
      * Method of destroy a service using a script.
      */
-    public OpenTofuResult destroyWithScripts(OpenTofuDestroyWithScriptsRequest request,
-                                             UUID uuid) {
+    public OpenTofuResult destroyWithScripts(OpenTofuDestroyWithScriptsRequest request, UUID uuid) {
         String taskWorkspace = scriptsHelper.buildTaskWorkspace(uuid.toString());
-        List<File> files =
-                scriptsHelper.prepareDeploymentFilesWithScripts(taskWorkspace, request.getScripts(),
-                        request.getTfState());
+        List<File> files = scriptsHelper.prepareDeploymentFilesWithScripts(taskWorkspace,
+                request.getScriptFiles(), request.getTfState());
         return directoryService.destroyFromDirectory(request, taskWorkspace, files);
     }
 
@@ -95,7 +91,8 @@ public class OpenTofuScriptsService {
     public OpenTofuPlan getOpenTofuPlanFromScripts(OpenTofuPlanWithScriptsRequest request,
                                                    UUID uuid) {
         String taskWorkspace = scriptsHelper.buildTaskWorkspace(uuid.toString());
-        scriptsHelper.prepareDeploymentFilesWithScripts(taskWorkspace, request.getScripts(), null);
+        scriptsHelper.prepareDeploymentFilesWithScripts(taskWorkspace, request.getScriptFiles(),
+                null);
         return directoryService.getOpenTofuPlanFromDirectory(request, uuid.toString());
     }
 
@@ -109,10 +106,9 @@ public class OpenTofuScriptsService {
         try {
             result = deployWithScripts(asyncDeployRequest, uuid);
         } catch (RuntimeException e) {
-            result =
-                    OpenTofuResult.builder().commandStdOutput(null).commandStdError(e.getMessage())
-                            .isCommandSuccessful(false).terraformState(null)
-                            .generatedFileContentMap(new HashMap<>()).build();
+            result = OpenTofuResult.builder().commandStdOutput(null).commandStdError(e.getMessage())
+                    .isCommandSuccessful(false).terraformState(null)
+                    .generatedFileContentMap(new HashMap<>()).build();
         }
         result.setRequestId(asyncDeployRequest.getRequestId());
         String url = asyncDeployRequest.getWebhookConfig().getUrl();
@@ -130,10 +126,9 @@ public class OpenTofuScriptsService {
         try {
             result = modifyWithScripts(asyncModifyRequest, uuid);
         } catch (RuntimeException e) {
-            result =
-                    OpenTofuResult.builder().commandStdOutput(null).commandStdError(e.getMessage())
-                            .isCommandSuccessful(false).terraformState(null)
-                            .generatedFileContentMap(new HashMap<>()).build();
+            result = OpenTofuResult.builder().commandStdOutput(null).commandStdError(e.getMessage())
+                    .isCommandSuccessful(false).terraformState(null)
+                    .generatedFileContentMap(new HashMap<>()).build();
         }
         result.setRequestId(asyncModifyRequest.getRequestId());
         String url = asyncModifyRequest.getWebhookConfig().getUrl();
@@ -145,16 +140,14 @@ public class OpenTofuScriptsService {
      * Async destroy resource of the service.
      */
     @Async(TaskConfiguration.TASK_EXECUTOR_NAME)
-    public void asyncDestroyWithScripts(OpenTofuAsyncDestroyFromScriptsRequest request,
-                                        UUID uuid) {
+    public void asyncDestroyWithScripts(OpenTofuAsyncDestroyFromScriptsRequest request, UUID uuid) {
         OpenTofuResult result;
         try {
             result = destroyWithScripts(request, uuid);
         } catch (RuntimeException e) {
-            result =
-                    OpenTofuResult.builder().commandStdOutput(null).commandStdError(e.getMessage())
-                            .isCommandSuccessful(false).terraformState(null)
-                            .generatedFileContentMap(new HashMap<>()).build();
+            result = OpenTofuResult.builder().commandStdOutput(null).commandStdError(e.getMessage())
+                    .isCommandSuccessful(false).terraformState(null)
+                    .generatedFileContentMap(new HashMap<>()).build();
         }
         result.setRequestId(request.getRequestId());
         String url = request.getWebhookConfig().getUrl();

--- a/src/main/java/org/eclipse/xpanse/tofu/maker/security/oauth2/config/Oauth2JwtDecoder.java
+++ b/src/main/java/org/eclipse/xpanse/tofu/maker/security/oauth2/config/Oauth2JwtDecoder.java
@@ -37,8 +37,8 @@ public class Oauth2JwtDecoder {
      * @return JwtDecoder.
      */
     @Retryable(retryFor = Exception.class,
-            maxAttemptsExpression = "${http.request.retry.max.attempts}",
-            backoff = @Backoff(delayExpression = "${http.request.retry.delay.milliseconds}"))
+            maxAttemptsExpression = "${spring.retry.max-attempts}",
+            backoff = @Backoff(delayExpression = "${spring.retry.delay-millions}"))
     public JwtDecoder createJwtDecoder(String issuerUri) {
         int retryCount = Objects.isNull(RetrySynchronizationManager.getContext())
                 ? 0 : RetrySynchronizationManager.getContext().getRetryCount();


### PR DESCRIPTION
Fixed https://github.com/eclipse-xpanse/xpanse/issues/2195

validate deployment scripts of registered service template with `tofu-maker`:
![tofu-maker](https://github.com/user-attachments/assets/0fcd62e0-1ab3-4076-8a90-0457a0346dac)
