### PR TITLE
add RestTemplateLoggingInterceptor

### DIFF
--- a/src/main/java/org/eclipse/xpanse/tofu/maker/config/RestTemplateConfig.java
+++ b/src/main/java/org/eclipse/xpanse/tofu/maker/config/RestTemplateConfig.java
@@ -5,6 +5,9 @@
 
 package org.eclipse.xpanse.tofu.maker.config;
 
+import jakarta.annotation.Resource;
+import java.util.Collections;
+import org.eclipse.xpanse.tofu.maker.logging.RestTemplateLoggingInterceptor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.ClientHttpRequestFactory;
@@ -15,10 +18,14 @@ import org.springframework.web.client.RestTemplate;
 @Configuration
 public class RestTemplateConfig {
 
+    @Resource RestTemplateLoggingInterceptor restTemplateLoggingInterceptor;
+
     /** Create RestTemplate to IOC. */
     @Bean
     public RestTemplate restTemplate(ClientHttpRequestFactory factory) {
-        return new RestTemplate(factory);
+        RestTemplate restTemplate = new RestTemplate(factory);
+        restTemplate.setInterceptors(Collections.singletonList(restTemplateLoggingInterceptor));
+        return restTemplate;
     }
 
     /** Create ClientHttpRequestFactory to IOC. */

--- a/src/main/java/org/eclipse/xpanse/tofu/maker/logging/CustomClientHttpResponse.java
+++ b/src/main/java/org/eclipse/xpanse/tofu/maker/logging/CustomClientHttpResponse.java
@@ -1,0 +1,52 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Huawei Inc.
+ *
+ */
+
+package org.eclipse.xpanse.tofu.maker.logging;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.lang.NonNull;
+
+/**
+ * The class wraps a ClientHttpResponse and provides easy access to its properties as a byte array.
+ */
+public record CustomClientHttpResponse(
+        ClientHttpResponse originalResponse, byte[] responseBodyBytes)
+        implements ClientHttpResponse {
+
+    @NonNull
+    @Override
+    public HttpStatusCode getStatusCode() throws IOException {
+        return originalResponse.getStatusCode();
+    }
+
+    @NonNull
+    @Override
+    public String getStatusText() throws IOException {
+        return originalResponse.getStatusText();
+    }
+
+    @NonNull
+    @Override
+    public HttpHeaders getHeaders() {
+        return originalResponse.getHeaders();
+    }
+
+    @NonNull
+    @Override
+    public InputStream getBody() {
+        return new ByteArrayInputStream(responseBodyBytes);
+    }
+
+    @Override
+    public void close() {
+        originalResponse.close();
+    }
+}

--- a/src/main/java/org/eclipse/xpanse/tofu/maker/logging/RestTemplateLoggingInterceptor.java
+++ b/src/main/java/org/eclipse/xpanse/tofu/maker/logging/RestTemplateLoggingInterceptor.java
@@ -1,0 +1,81 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Huawei Inc.
+ *
+ */
+
+package org.eclipse.xpanse.tofu.maker.logging;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.lang.NonNull;
+import org.springframework.util.StreamUtils;
+
+/** The class logs HTTP requests and responses made by RestTemplate. */
+@Configuration
+@Slf4j
+public class RestTemplateLoggingInterceptor implements ClientHttpRequestInterceptor {
+
+    @Override
+    @NonNull
+    public ClientHttpResponse intercept(
+            @NonNull HttpRequest request,
+            @NonNull byte[] body,
+            @NonNull ClientHttpRequestExecution execution)
+            throws IOException {
+        long startTime = System.currentTimeMillis();
+        logRequest(request, body);
+        ClientHttpResponse originalResponse = execution.execute(request, body);
+        byte[] responseBodyBytes = StreamUtils.copyToByteArray(originalResponse.getBody());
+        logResponse(originalResponse, responseBodyBytes, startTime);
+        return new CustomClientHttpResponse(originalResponse, responseBodyBytes);
+    }
+
+    private void logRequest(HttpRequest request, byte[] body) {
+        if (log.isInfoEnabled()) {
+            String requestBody = new String(body, StandardCharsets.UTF_8);
+            final StringBuilder requestResult = new StringBuilder(requestBody.length() + 2048);
+            requestResult.append("Request: ");
+            requestResult.append(request.getMethod());
+            requestResult.append(' ');
+            requestResult.append(request.getURI());
+            requestResult.append(' ');
+            writeBody(requestBody, requestResult);
+            log.info(requestResult.toString());
+        }
+    }
+
+    private void logResponse(ClientHttpResponse response, byte[] responseBodyBytes, long startTime)
+            throws IOException {
+        if (log.isInfoEnabled()) {
+            String responseBody = new String(responseBodyBytes, StandardCharsets.UTF_8);
+            final StringBuilder responseResult = new StringBuilder(responseBody.length() + 2048);
+            responseResult.append("Response: ");
+            responseResult.append(response.getStatusCode());
+            String statusText = response.getStatusText();
+            responseResult.append(' ');
+            responseResult.append(statusText);
+            responseResult.append(" Duration: ");
+            responseResult.append(System.currentTimeMillis() - startTime);
+            responseResult.append("ms");
+            responseResult.append(' ');
+            writeBody(responseBody, responseResult);
+            log.info(responseResult.toString());
+        }
+    }
+
+    private void writeBody(final String body, final StringBuilder output) {
+        if (!body.isEmpty()) {
+            output.append(' ');
+            output.append(body);
+        } else {
+            output.setLength(output.length() - 1); // discard last newline
+        }
+    }
+}


### PR DESCRIPTION
Part of [eclipse-expanse/expanse#2353](https://github.com/eclipse-xpanse/xpanse/issues/2353)

Tested locally, example log when requesting to google
```
20250203 10:01:35.284 [thread-pool-4] INFO  o.e.x.t.m.l.RestTemplateLoggingInterceptor [ff68c267-3ab6-40cd-822d-d1a886d78577] [3fa85f64-5717-4562-b3fc-2c963f66afa6]- Request: POST https://www.google.com  //request body redacted
20250203 10:01:35.285 [thread-pool-4] INFO  o.e.x.t.m.l.RestTemplateLoggingInterceptor [ff68c267-3ab6-40cd-822d-d1a886d78577] [3fa85f64-5717-4562-b3fc-2c963f66afa6]- Response: 405 METHOD_NOT_ALLOWED Method Not Allowed // response body redacted
```